### PR TITLE
Bump for release: v0.2.1

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -31,7 +31,7 @@
         "arm64",
         "arm"
     ],
-    "branch": "v0.2",
+    "branch": "v0.2.1",
     "license": "BSD",
     "icon": "https://0000.us/klatchat/app/files/neon_images/icons/neon_skill.png",
     "category": "Daily",


### PR DESCRIPTION
New release is needed because the previous release missed `skill.json`; new PR is needed because the previous bump PR occurred after the release. Everybody's git-fu is lousy today.